### PR TITLE
change workflow job to workflow run

### DIFF
--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -353,7 +353,9 @@ definitions:
         type: string
         description: |-
           An email address or web page URL with contact information
-          for the operator of a specific WES endpoint.
+          for the operator of a specific WES endpoint.  Users of the
+          endpoint should use this to report problems or security
+          vulnerabilities.
       tags:
         type: object
         additionalProperties:

--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -41,20 +41,20 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       tags:
         - WorkflowExecutionService
-  /workflow-jobs:
+  /workflow-runs:
     get:
       summary: |-
-        List the workflow jobs, this endpoint will list the jobs in order of oldest to newest.
+        List the workflow runs, this endpoint will list the runs in order of oldest to newest.
         There is no guarantee of live updates as the user traverses the pages, the behavior should be
         decided (and documented) by each implementation.
-        To monitor a given execution, use GetJobStatus or GetJobLog.
+        To monitor a given execution, use GetRunStatus or GetRunLog.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: ListJobs
+      operationId: ListRuns
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/JobListResponse'
+            $ref: '#/definitions/RunListResponse'
         '400':
           description: The request is malformed.
           schema:
@@ -75,7 +75,7 @@ paths:
         - name: page_size
           description: |-
             OPTIONAL
-            Number of jobs to return in a page.
+            Number of runs to return in a page.
           in: query
           required: false
           type: integer
@@ -91,7 +91,7 @@ paths:
         - name: tag_search
           description: |-
             OPTIONAL
-            For each key, if the key's value is empty string then match jobs that are tagged with
+            For each key, if the key's value is empty string then match runs that are tagged with
             this key regardless of value.
           in: query
           required: false
@@ -100,9 +100,9 @@ paths:
         - WorkflowExecutionService
     post:
       summary: |-
-        Submit a workflow job, this endpoint will allow you to create a new job request and
+        Submit a workflow run, this endpoint will allow you to create a new run request and
         retrieve its tracking ID to monitor its progress.  An important assumption in this
-        endpoint is that the job_params JSON will include parameterizations along with
+        endpoint is that the run_params JSON will include parameterizations along with
         input and output files.  The latter two may be on S3, Google object storage, local filesystems,
         etc.  This specification makes no distinction.  However, it is assumed that the submitter
         is using URLs that this system both understands and can access. For Amazon S3, this could
@@ -110,12 +110,12 @@ paths:
         particular bucket.  The details are important for a production system and user on-boarding
         but outside the scope of this spec.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: RunJob
+      operationId: RunWorkflow
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/JobId'
+            $ref: '#/definitions/RunId'
         '400':
           description: The request is malformed.
           schema:
@@ -137,25 +137,25 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/JobRequest'
+            $ref: '#/definitions/RunRequest'
       tags:
         - WorkflowExecutionService
-  /workflow-jobs/{job_id}:
+  /workflow-runs/{run_id}:
     get:
-      summary: Get detailed info about a workflow job.
+      summary: Get detailed info about a workflow run.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: GetJobLog
+      operationId: GetRunLog
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/JobLog'
+            $ref: '#/definitions/RunLog'
         '401':
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '404':
-          description: The requested Workflow job not found.
+          description: The requested Workflow run not found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '403':
@@ -167,21 +167,21 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       parameters:
-        - name: job_id
+        - name: run_id
           in: path
           required: true
           type: string
       tags:
         - WorkflowExecutionService
     delete:
-      summary: Cancel a running job.
+      summary: Cancel a running run.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: CancelJob
+      operationId: CancelRun
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/JobId'
+            $ref: '#/definitions/RunId'
         '401':
           description: The request is unauthorized.
           schema:
@@ -199,28 +199,28 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       parameters:
-        - name: job_id
+        - name: run_id
           in: path
           required: true
           type: string
       tags:
         - WorkflowExecutionService
-  /workflow-jobs/{job_id}/status:
+  /workflow-runs/{run_id}/status:
     get:
-      summary: Get quick status info about a workflow job.
+      summary: Get quick status info about a workflow run.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: GetJobStatus
+      operationId: GetRunStatus
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/JobStatus'
+            $ref: '#/definitions/RunStatus'
         '401':
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '404':
-          description: The requested workflow job wasn't found.
+          description: The requested workflow run wasn't found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '403':
@@ -232,7 +232,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
       parameters:
-        - name: job_id
+        - name: run_id
           in: path
           required: true
           type: string
@@ -322,12 +322,12 @@ definitions:
           type: integer
           format: int64
         description: |-
-          The system statistics, key is the statistic, value is the count of jobs in that state.
+          The system statistics, key is the statistic, value is the count of runs in that state.
           See the State enum for the possible keys.
       auth_instructions_url:
         type: string
         description: |-
-          A URL that will help a in generating the tokens necessary to run a workflow job using this
+          A URL that will help a in generating the tokens necessary to run a workflow run using this
           service.
       tags:
         type: object
@@ -374,55 +374,55 @@ definitions:
       for example an upload failed due to network issues, the worker's ran out
       of disk space, etc.
        - CANCELED: The task was canceled by the user.
-    title: Enumeration of states for a given job request
-  JobDescription:
+    title: Enumeration of states for a given run request
+  RunDescription:
     type: object
     properties:
-      job_id:
+      run_id:
         type: string
         title: REQUIRED
       state:
         $ref: '#/definitions/State'
         title: REQUIRED
-    title: 'Small description of jobs, returned by server during listing'
-  JobListResponse:
+    title: 'Small description of runs, returned by server during listing'
+  RunListResponse:
     type: object
     properties:
-      jobs:
+      runs:
         type: array
         items:
-          $ref: '#/definitions/JobDescription'
-        description: A list of workflow jobs that the service has executed or is executing.
+          $ref: '#/definitions/RunDescription'
+        description: A list of workflow runs that the service has executed or is executing.
       next_page_token:
         type: string
         description: |-
-          A token, which when provided in a job_list_request, allows one to retrieve the next page
+          A token, which when provided in a run_list_request, allows one to retrieve the next page
           of results.
-    description: The service will return a job_list_response when receiving a successful job_list_request.
-  JobLog:
+    description: The service will return a run_list_response when receiving a successful run_list_request.
+  RunLog:
     type: object
     properties:
-      job_id:
+      run_id:
         type: string
-        title: job ID
+        title: run ID
       request:
-        $ref: '#/definitions/JobRequest'
+        $ref: '#/definitions/RunRequest'
         description: The original request message used to initiate this execution.
       state:
         $ref: '#/definitions/State'
         title: state
-      job_log:
+      run_log:
         $ref: '#/definitions/Log'
-        title: 'the logs, and other key info like timing and exit code, for the overall run of this job'
+        title: 'the logs, and other key info like timing and exit code, for the overall run of this run'
       task_logs:
         type: array
         items:
           $ref: '#/definitions/Log'
-        title: 'the logs, and other key info like timing and exit code, for each step in the job'
+        title: 'the logs, and other key info like timing and exit code, for each step in the run'
       outputs:
         $ref: '#/definitions/WesObject'
         title: the outputs
-  JobRequest:
+  RunRequest:
     type: object
     properties:
       workflow_descriptor:
@@ -434,11 +434,11 @@ definitions:
           CWL, WDL, or a base64 encoded gzip of the required workflow descriptors. When files must be
           created in this way, the `workflow_url` should be set to the path of the main
           workflow descriptor.
-      job_params:
+      workflow_params:
         $ref: '#/definitions/WesObject'
         description: |-
           REQUIRED
-          The workflow job parameterization document (typically a JSON file), includes all parameterizations for the job
+          The workflow run parameterization document (typically a JSON file), includes all parameterizations for the run
           including input and output file locations.
       workflow_type:
         type: string
@@ -456,7 +456,7 @@ definitions:
           type: string
         title: |-
           OPTIONAL
-          A key-value map of arbitrary metadata outside the scope of the job_params but useful to track with this job request
+          A key-value map of arbitrary metadata outside the scope of the run_params but useful to track with this run request
       workflow_engine_parameters:
         type: object
         additionalProperties:
@@ -473,20 +473,20 @@ definitions:
           workflow descriptor files is offered, the `workflow_url` should be set to the relative path
           of the main workflow descriptor.
     description: |-
-      To execute a workflow job, send a job request including all the details needed to begin downloading
-      and executing a given job.
-  JobId:
+      To execute a workflow run, send a run request including all the details needed to begin downloading
+      and executing a given run.
+  RunId:
     type: object
     properties:
-      job_id:
+      run_id:
         type: string
-        title: job ID
-  JobStatus:
+        title: run ID
+  RunStatus:
     type: object
     properties:
-      job_id:
+      run_id:
         type: string
-        title: job ID
+        title: run ID
       state:
         $ref: '#/definitions/State'
         title: state
@@ -501,7 +501,7 @@ definitions:
           an array of one or more acceptable types for the Workflow Type. For
           example, to send a base64 encoded WDL gzip, one could would offer
           "base64_wdl1.0_gzip". By setting this value, and the path of the main WDL
-          to be executed in the workflow_url to "main.wdl" in the JobRequest.
+          to be executed in the workflow_url to "main.wdl" in the RunRequest.
     description: Available workflow types supported by a given instance of the service.
   WesObject:
     type: object

--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -347,8 +347,13 @@ definitions:
       auth_instructions_url:
         type: string
         description: |-
-          A URL that will help a in generating the tokens necessary to run a workflow using this
-          service.
+          A web page URL with information about how to get an
+          authorization token necessary to use a specific endpoint.
+     contact_info:
+        type: string
+        description: |-
+          An email address or web page URL with contact information
+          for the operator of a specific WES endpoint.
       tags:
         type: object
         additionalProperties:

--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -44,10 +44,13 @@ paths:
   /workflows:
     get:
       summary: |-
-        List the workflows, this endpoint will list the workflows in order of oldest to newest.
-        There is no guarantee of live updates as the user traverses the pages, the behavior should be
-        decided (and documented) by each implementation.
-        To monitor a given execution, use GetWorkflowStatus or GetWorkflowLog.
+        List submitted workflows.  This should be provided in a stable
+        ordering, however the ordering of this list is implementation
+        dependent.  When paging through the list, the client should
+        not make assumptions about live updates, but should assume the
+        contents of the list reflect the workflow list at the moment
+        that the first page is requested.  To monitor a specific
+        workflow run, use GetWorkflowStatus or GetWorkflowLog.
       x-swagger-router-controller: ga4gh.wes.server
       operationId: ListWorkflows
       responses:
@@ -75,7 +78,14 @@ paths:
         - name: page_size
           description: |-
             OPTIONAL
-            Number of workflows to return in a page.
+            The preferred number of workflow runs to return in a page.
+            If not provided, the implementation should use a default page size.
+            The implementation must not return more items
+            than "page_size", but it may return fewer.  Clients should
+            not assume that if fewer than "page_size" items is
+            returned that all items have been returned.  The
+            availability of additional pages is indicated by the value
+            of "next_page_token" in the response.
           in: query
           required: false
           type: integer
@@ -83,7 +93,7 @@ paths:
         - name: page_token
           description: |-
             OPTIONAL
-            Token to use to indicate where to start getting results. If unspecified, returns the first
+            Token to use to indicate where to start getting results. If unspecified, return the first
             page of results.
           in: query
           required: false
@@ -264,16 +274,26 @@ definitions:
         title: The command line that was run
       start_time:
         type: string
-        title: When the command was executed
+        title: When the command started executing, in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
       end_time:
         type: string
-        title: When the command completed
+        title: When the command stopped executing (completed, failed, or cancelled), in ISO 8601 format "%Y-%m-%dT%H:%M:%SZ"
       stdout:
         type: string
-        title: Sample of stdout (not guaranteed to be entire log)
+        title: |-
+          A URL to retrieve standard output logs of the workflow run or
+          task.  This URL may change between status requests, or may
+          not be available until the task or workflow has finished
+          execution.  Should be available using the same credentials
+          used to access the WES endpoint.
       stderr:
         type: string
-        title: Sample of stderr (not guaranteed to be entire log)
+        title: |-
+          A URL to retrieve standard error logs of the workflow run or
+          task.  This URL may change between status requests, or may
+          not be available until the task or workflow has finished
+          execution.  Should be available using the same credentials
+          used to access the WES endpoint.
       exit_code:
         type: integer
         format: int32
@@ -396,8 +416,8 @@ definitions:
       next_page_token:
         type: string
         description: |-
-          A token, which when provided in a workflow_list_request, allows one to retrieve the next page
-          of results.
+          A token which may be supplied as "page_token" in workflow list request to get the next page
+          of results.  An empty string indicates there are no more items to return.
     description: The service will return a workflow_list_response when receiving a successful workflow_list_request.
   WorkflowLog:
     type: object

--- a/openapi/workflow_execution_service.swagger.yaml
+++ b/openapi/workflow_execution_service.swagger.yaml
@@ -47,14 +47,14 @@ paths:
         List the workflow runs, this endpoint will list the runs in order of oldest to newest.
         There is no guarantee of live updates as the user traverses the pages, the behavior should be
         decided (and documented) by each implementation.
-        To monitor a given execution, use GetRunStatus or GetRunLog.
+        To monitor a given execution, use GetWorkflowRunStatus or GetWorkflowRunLog.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: ListRuns
+      operationId: ListWorkflowRuns
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/RunListResponse'
+            $ref: '#/definitions/WorkflowRunListResponse'
         '400':
           description: The request is malformed.
           schema:
@@ -75,7 +75,7 @@ paths:
         - name: page_size
           description: |-
             OPTIONAL
-            Number of runs to return in a page.
+            Number of workflow runs to return in a page.
           in: query
           required: false
           type: integer
@@ -102,7 +102,7 @@ paths:
       summary: |-
         Submit a workflow run, this endpoint will allow you to create a new run request and
         retrieve its tracking ID to monitor its progress.  An important assumption in this
-        endpoint is that the run_params JSON will include parameterizations along with
+        endpoint is that the workflow_params JSON will include parameterizations along with
         input and output files.  The latter two may be on S3, Google object storage, local filesystems,
         etc.  This specification makes no distinction.  However, it is assumed that the submitter
         is using URLs that this system both understands and can access. For Amazon S3, this could
@@ -115,7 +115,7 @@ paths:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/RunId'
+            $ref: '#/definitions/WorkflowRunId'
         '400':
           description: The request is malformed.
           schema:
@@ -137,25 +137,25 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/RunRequest'
+            $ref: '#/definitions/WorkflowRunRequest'
       tags:
         - WorkflowExecutionService
   /workflow-runs/{run_id}:
     get:
       summary: Get detailed info about a workflow run.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: GetRunLog
+      operationId: GetWorkflowRunLog
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/RunLog'
+            $ref: '#/definitions/WorkflowRunLog'
         '401':
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '404':
-          description: The requested Workflow run not found.
+          description: The requested workflow run not found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '403':
@@ -174,20 +174,20 @@ paths:
       tags:
         - WorkflowExecutionService
     delete:
-      summary: Cancel a running run.
+      summary: Cancel a running workflow.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: CancelRun
+      operationId: CancelWorkflowRun
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/RunId'
+            $ref: '#/definitions/WorkflowRunId'
         '401':
           description: The request is unauthorized.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '404':
-          description: The requested Workflow wasn't found.
+          description: The requested workflow run wasn't found.
           schema:
             $ref: '#/definitions/ErrorResponse'
         '403':
@@ -209,12 +209,12 @@ paths:
     get:
       summary: Get quick status info about a workflow run.
       x-swagger-router-controller: ga4gh.wes.server
-      operationId: GetRunStatus
+      operationId: GetWorkflowRunStatus
       responses:
         '200':
           description: ''
           schema:
-            $ref: '#/definitions/RunStatus'
+            $ref: '#/definitions/WorkflowRunStatus'
         '401':
           description: The request is unauthorized.
           schema:
@@ -261,7 +261,7 @@ definitions:
         type: array
         items:
           type: string
-        title: The command line that was run
+        title: The command line that was executed
       start_time:
         type: string
         title: When the command was executed
@@ -375,7 +375,7 @@ definitions:
       of disk space, etc.
        - CANCELED: The task was canceled by the user.
     title: Enumeration of states for a given run request
-  RunDescription:
+  WorkflowRunDescription:
     type: object
     properties:
       run_id:
@@ -384,45 +384,45 @@ definitions:
       state:
         $ref: '#/definitions/State'
         title: REQUIRED
-    title: 'Small description of runs, returned by server during listing'
-  RunListResponse:
+    title: 'Small description of workflow runs, returned by server during listing'
+  WorkflowRunListResponse:
     type: object
     properties:
-      runs:
+      workflow_runs:
         type: array
         items:
-          $ref: '#/definitions/RunDescription'
+          $ref: '#/definitions/WorkflowRunDescription'
         description: A list of workflow runs that the service has executed or is executing.
       next_page_token:
         type: string
         description: |-
-          A token, which when provided in a run_list_request, allows one to retrieve the next page
+          A token, which when provided in a workflow_run_list_request, allows one to retrieve the next page
           of results.
-    description: The service will return a run_list_response when receiving a successful run_list_request.
-  RunLog:
+    description: The service will return a workflow_run_list_response when receiving a successful workflow_run_list_request.
+  WorkflowRunLog:
     type: object
     properties:
       run_id:
         type: string
-        title: run ID
+        title: workflow run ID
       request:
-        $ref: '#/definitions/RunRequest'
+        $ref: '#/definitions/WorkflowRunRequest'
         description: The original request message used to initiate this execution.
       state:
         $ref: '#/definitions/State'
         title: state
       run_log:
         $ref: '#/definitions/Log'
-        title: 'the logs, and other key info like timing and exit code, for the overall run of this run'
+        title: 'the logs, and other key info like timing and exit code, for the overall run of this workflow'
       task_logs:
         type: array
         items:
           $ref: '#/definitions/Log'
-        title: 'the logs, and other key info like timing and exit code, for each step in the run'
+        title: 'the logs, and other key info like timing and exit code, for each step in the workflow run'
       outputs:
         $ref: '#/definitions/WesObject'
         title: the outputs
-  RunRequest:
+  WorkflowRunRequest:
     type: object
     properties:
       workflow_descriptor:
@@ -473,20 +473,20 @@ definitions:
           workflow descriptor files is offered, the `workflow_url` should be set to the relative path
           of the main workflow descriptor.
     description: |-
-      To execute a workflow run, send a run request including all the details needed to begin downloading
-      and executing a given run.
-  RunId:
+      To execute a workflow, send a run request including all the details needed to begin downloading
+      and executing a given workflow.
+  WorkflowRunId:
     type: object
     properties:
       run_id:
         type: string
-        title: run ID
-  RunStatus:
+        title: workflow run ID
+  WorkflowRunStatus:
     type: object
     properties:
       run_id:
         type: string
-        title: run ID
+        title: workflow run ID
       state:
         $ref: '#/definitions/State'
         title: state
@@ -501,7 +501,7 @@ definitions:
           an array of one or more acceptable types for the Workflow Type. For
           example, to send a base64 encoded WDL gzip, one could would offer
           "base64_wdl1.0_gzip". By setting this value, and the path of the main WDL
-          to be executed in the workflow_url to "main.wdl" in the RunRequest.
+          to be executed in the workflow_url to "main.wdl" in the WorkflowRunRequest.
     description: Available workflow types supported by a given instance of the service.
   WesObject:
     type: object

--- a/python/ga4gh/wes/controllers.py
+++ b/python/ga4gh/wes/controllers.py
@@ -5,15 +5,15 @@ Controllers for the workflow execution service
 DEFAULT_PAGE_SIZE = 100
 
 
-def GetRunLog(**kwargs):
+def GetWorkflowRunLog(**kwargs):
     return {}
 
 
-def CancelRun(**kwargs):
+def CancelWorkflowRun(**kwargs):
     return {}
 
 
-def ListRunss(**kwargs):
+def ListWorkflowRuns(**kwargs):
     return {}
 
 
@@ -25,5 +25,5 @@ def RunWorkflow(**kwargs):
     return {}
 
 
-def GetRunStatus(**kwargs):
+def GetWorkflowRunStatus(**kwargs):
     return {}

--- a/python/ga4gh/wes/controllers.py
+++ b/python/ga4gh/wes/controllers.py
@@ -5,15 +5,15 @@ Controllers for the workflow execution service
 DEFAULT_PAGE_SIZE = 100
 
 
-def GetJobLog(**kwargs):
+def GetRunLog(**kwargs):
     return {}
 
 
-def CancelJob(**kwargs):
+def CancelRun(**kwargs):
     return {}
 
 
-def ListJobs(**kwargs):
+def ListRunss(**kwargs):
     return {}
 
 
@@ -21,9 +21,9 @@ def GetServiceInfo(**kwargs):
     return {}
 
 
-def RunJob(**kwargs):
+def RunWorkflow(**kwargs):
     return {}
 
 
-def GetJobStatus(**kwargs):
+def GetRunStatus(**kwargs):
     return {}


### PR DESCRIPTION
Based on some discussions in Toronto, I changed "job" to "run" throughout the spec. I'm not sure if people have a strong preference between the use of `Run` vs. `WorkflowRun` for some endpoints.